### PR TITLE
nix/package: enable content-addressed outputs

### DIFF
--- a/bootstrap/lib.nu
+++ b/bootstrap/lib.nu
@@ -43,7 +43,8 @@ export def copy-tree [from: path, to: path, pattern: string = "**/*"]: nothing -
   glob $"($from)/($pattern)" | where { ($in | path type) == "file" } | par-each --threads (cores) {|f|
     let dest = $"($to)/($f | path relative-to $from)"
     mkdir ($dest | path dirname)
-    cp -f $f $dest
+    # Nushell's in-process `cp` can corrupt concurrent copies; each external cp has isolated state.
+    ^cp -f $f $dest
   } | ignore
 }
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -63,6 +63,9 @@ let
   setCommon = {
     inherit (platform) system;
     __structuredAttrs = true;
+    __contentAddressed = true;
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
     builder = "${nu}/bin/nu";
     # platform facts autoconf would otherwise probe (or guess, when cross): nix/config.site
     CONFIG_SITE = "${../nix/config.site}";


### PR DESCRIPTION
I tested builds up to git, everything works fine so far. Every dynamic deriration was already content-adressed, this pr extends it to all other derivations. Also fixes failure for `nix-build -A git --builders ""`