### PR TITLE
phases as edits to the build system's list: before, after, replace, remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,19 @@ LuaRocks, the lock file in the source is turned into fixed-output fetches at bui
 dynamic derivation, with the hashes the lock file already has. Where it has none (Go, Hackage,
 LuaRocks) they are kept in `locks/*.toml`.
 
-If a package needs something between or instead of those, it writes `phases` out. Each entry
-is either a phase of the build system or a piece of nu with a name. Inside the nu, `$c` holds the
-paths and facts of the build (`$c.out`, `$c.src`, `$c.build`, `$c.njobs`, `$c.platform`):
+If a package needs something between or instead of those, `phases` edits the build system's
+list: `before.<phase>`, `after.<phase>`, `replace.<phase>` take a phase or a list, `remove` a
+list. A phase is one of a build system's or a piece of nu with a name. Inside the nu, `$c` holds
+the paths and facts of the build (`$c.out`, `$c.src`, `$c.build`, `$c.njobs`, `$c.platform`):
 
 ```nix
-phases = [
-  "autotools.configure"
-  "autotools.build"
-  { name = "trim"; run = ''rm $"($c.out)/bin/unwanted"''; }
-  "autotools.install"
+phases.before."autotools.install" = [
+  { name = "trim"; run = ''rm $"($c.build)/unwanted"''; }
 ];
+phases.remove = [ "autotools.test" ];
 ```
+
+`phases = [ … ]` spells the whole list out instead, needed with more than one build system.
 
 Phases too long to keep inline can live in their own file: `modules.rust = ./build.nu;` makes it
 a module, and `phases` refers to them as `"rust.configure"`. pkgs/ru/rust does this.

--- a/docs/design.md
+++ b/docs/design.md
@@ -118,7 +118,7 @@ modules exporting `setup configure build test install`. A package names them:
 ```nix
 uses = [ "cmake" ];                                   # phases default to the build system's
 cmake.defs = { WITH_FOO = true; };                    # typed options, checked at eval
-phases = [ "cmake.configure" { name = "x"; run = "<nu>"; } ];   # only when the default does not fit
+phases.after."cmake.install" = [ { name = "x"; run = "<nu>"; } ]; # edits, or the whole list
 phases = [ "foo.gen" "cmake.build" ];                 # foo.<phase> lives in foo.nu beside package.nix
 ```
 

--- a/nix/build-systems.nix
+++ b/nix/build-systems.nix
@@ -59,6 +59,8 @@ builtins.mapAttrs
       // (if bs ? tool then { tool = opt "set" bs.tool "the package that provides ${name}"; } else { })
       // bs.options;
       extra = if builtins.isFunction (bs.tools or [ ]) then bs.tools else _: bs.tools or [ ];
+      # one set per build system, only `lock` options depend on the package
+      optionDefaults = builtins.mapAttrs (_: o: o.default) options;
     in
     {
       inherit options;
@@ -70,11 +72,31 @@ builtins.mapAttrs
           "install"
         ]
       );
+      # script text nix/package.nix would otherwise assemble per package: the setup block and,
+      # for any "<name>.<verb>" a package may list, its body and whether it is a test phase
+      setup = "note setup ${name}\ndo --env {\nmkdir (${name} workdir)\ncd (${name} workdir)\n${name} setup\n}";
+      phase = builtins.listToAttrs (
+        map
+          (verb: {
+            name = "${name}.${verb}";
+            value = {
+              test = verb == "test";
+              body = "note phase ${name}.${verb}\ndo {\ncd (${name} workdir)\n${name} ${verb}\n}";
+            };
+          })
+          [
+            "configure"
+            "build"
+            "test"
+            "install"
+          ]
+      );
       # what the package's `<name>` record starts from: every option's default, `lock` ones fetched
       defaults =
-        args:
-        builtins.mapAttrs (_: o: o.default) options
-        // builtins.mapAttrs (_: f: f { inherit (args) source; }) (bs.lock or { });
+        if bs ? lock then
+          args: optionDefaults // builtins.mapAttrs (_: f: f { inherit (args) source; }) bs.lock
+        else
+          _: optionDefaults;
       # `tool`: the build system's own program, a package may swap it (`cmake.tool = …`)
       tools = spec: (if bs ? tool then [ spec.${name}.tool ] else [ ]) ++ extra spec;
       dependencies = bs.dependencies or [ ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,6 +34,8 @@ let
     match
     ;
 
+  # the builder modules every script imports: one string for the set
+  preludeCommon = "use ${tree}/core.nu *\nuse ${tree}/prepare.nu\nuse ${tree}/finish.nu\nuse ${tree}/implant.nu";
   tree = builtins.path {
     path = ../builder;
     name = "build";
@@ -101,16 +103,6 @@ let
     };
   };
   phaseRe = "([a-z][a-z0-9]*)\\.([a-zA-Z]+)";
-  # "<bs>.test" or an inline phase named "test"
-  isTest =
-    s:
-    if isAttrs s then
-      s.name == "test"
-    else
-      let
-        p = match phaseRe s;
-      in
-      p != null && elemAt p 1 == "test";
 in
 # sources: the package's sources.toml (nix/sources.nix) or null. It supplies version and source
 # unless package.nix sets them (local trees, demos)
@@ -183,9 +175,9 @@ let
     else
       [ ];
   unknownFields =
-    filter (f: !(elem f (reserved ++ uses))) (attrNames args)
-    ++ subKeys "tests" (args.tests or { })
-    ++ subKeys "cc" (args.cc or { });
+    attrNames (removeAttrs args (reserved ++ uses))
+    ++ (if args ? tests then subKeys "tests" args.tests else [ ])
+    ++ (if args ? cc then subKeys "cc" args.cc else [ ]);
   # one message per option the package sets that its build system does not declare, or declares
   # with another type. Shallow (`typeOf`) on set options only, so it costs nothing per default.
   badOptions = concatMap (
@@ -335,44 +327,68 @@ let
     "--experimental-options=[cell-path-types]"
     "-c"
   ];
-  # a phase's nu text, ungated
-  phaseBody =
+  # a phase as { test, body }: inline ones and package-module ones built here, a build system's
+  # come ready from nix/build-systems.nix. A prefix that is neither: nix reports "path …/<bs>.nu
+  # does not exist"
+  phase =
     s:
     if isAttrs s then
-      "note phase ${s.name}\ndo {\ncd (${workdir})\nlet c = (ctx)\n${s.run}\n}"
+      {
+        test = s.name == "test";
+        body = "note phase ${s.name}\ndo {\ncd (${workdir})\nlet c = (ctx)\n${s.run}\n}";
+      }
     else
-      let
-        p = match phaseRe s;
-        bs = elemAt p 0;
-        call =
-          if elem bs uses then "do {\ncd (${bs} workdir)\n${bs} ${elemAt p 1}\n}" else "${bs} ${elemAt p 1}";
-      in
-      # a prefix that is neither: nix reports "path …/<bs>.nu does not exist"
-      if p == null then
-        fail "phase '${s}' is not <build system or module>.<phase>"
-      else
-        "note phase ${s}\n${call}";
+      bsPhases.${s} or (
+        let
+          p = match phaseRe s;
+        in
+        if p == null then
+          fail "phase '${s}' is not <build system or module>.<phase>"
+        else if elem (elemAt p 0) uses then
+          {
+            test = false;
+            body = "note phase ${s}\ndo {\ncd (${elemAt p 0} workdir)\n${elemAt p 0} ${elemAt p 1}\n}";
+          }
+        else
+          {
+            test = elemAt p 1 == "test";
+            body = "note phase ${s}\n${elemAt p 0} ${elemAt p 1}";
+          }
+      );
+  # "<bs>.<verb>" -> { test, body } for the build systems in use, ready made in build-systems.nix
+  bsPhases =
+    if length uses == 1 then
+      buildSystems.${head uses}.phase
+    else
+      foldl' (a: u: a // buildSystems.${u}.phase) { } uses;
   # in the build script: test phases drop out when disabled or separate, and otherwise ask prepare
   # (cross without binfmt decides at build time that tests cannot run)
   phaseLine =
     s:
-    if !isTest s then
-      phaseBody s
+    let
+      p = phase s;
+    in
+    if !p.test then
+      p.body
     else if !testsRun || separate then
       ""
     else
-      "if (ctx).testsRun {\n${phaseBody s}\n}";
+      "if (ctx).testsRun {\n${p.body}\n}";
   # a phase "zig.restore" whose prefix is no `uses` entry is the package's own module zig.nu next
   # to package.nix, for phases too long to read inline. It imports the builder by bare name
-  modules = foldl' (acc: m: if m == null || elem m (uses ++ acc) then acc else acc ++ [ m ]) [ ] (
-    map (
-      s:
-      let
-        p = if isAttrs s then null else match phaseRe s;
-      in
-      if p == null then null else head p
-    ) phases
-  );
+  modules =
+    if !(args ? phases) then
+      [ ]
+    else
+      foldl' (acc: m: if m == null || elem m (uses ++ acc) then acc else acc ++ [ m ]) [ ] (
+        map (
+          s:
+          let
+            p = if isAttrs s then null else match phaseRe s;
+          in
+          if p == null then null else head p
+        ) phases
+      );
   # <store dir>/<m>.nu: nu names a module after its file, a bare store path would be <hash>-<m>
   storeModule =
     m:
@@ -383,23 +399,15 @@ let
         filter = p: _: baseNameOf p == "${m}.nu";
       }
     }/${m}.nu";
-  prelude =
-    map (f: "use ${tree}/${f}") (
-      [
-        "core.nu *"
-        "prepare.nu"
-        "finish.nu"
-        "implant.nu"
-      ]
-      ++ map (u: buildSystems.${u}.module) uses
-    )
-    ++ map (m: "use ${storeModule m}") modules;
+  prelude = [
+    preludeCommon
+  ]
+  ++ map (u: "use ${tree}/${buildSystems.${u}.module}") uses
+  ++ map (m: "use ${storeModule m}") modules;
   # every phase starts in a known directory: `<bs> workdir` for a build system's phases, the first
   # build system's for inline phases and package modules. setup exports env, hence --env
   workdir = if uses == [ ] then "(ctx).src" else "${builtins.head uses} workdir";
-  setups = map (
-    u: "note setup ${u}\ndo --env {\nmkdir (${u} workdir)\ncd (${u} workdir)\n${u} setup\n}"
-  ) uses;
+  setups = map (u: buildSystems.${u}.setup) uses;
   # also `pkg.script`: lints/package-scripts.nu has nu parse it before anything builds
   script = concatStringsSep "\n" (
     prelude
@@ -412,7 +420,7 @@ let
     prelude
     ++ [ "prepare --from-tree ${drv.tree}" ]
     ++ setups
-    ++ map phaseBody (filter isTest phases)
+    ++ map (p: p.body) (filter (p: p.test) (map phase phases))
     ++ [ "finish tests" ]
   );
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -28,6 +28,7 @@ let
     foldl'
     head
     isAttrs
+    isList
     length
     listToAttrs
     match
@@ -260,16 +261,52 @@ let
     else
       true;
 
-  # `install`/`links` alone (prebuilt binaries, data): the one phase is copying them into $out
+  # `install`/`links` alone (prebuilt binaries, data): the one phase is copying them into $out.
+  # `phases` is the whole list, or edits to the first build system's list (README):
+  # { before.<phase> = [..]; after.<phase> = [..]; replace.<phase> = phase | [..]; remove = [..]; }
   phases =
-    args.phases or (
+    if !(args ? phases) then
       if length uses == 1 then
         buildSystems.${head uses}.phases
       else if uses == [ ] && (args ? install || args ? links) then
         [ ]
       else
-        fail "'phases' is required with more than one build system"
-    );
+        fail "'phases' is required with more than one build system (a list, or edits to the first one's)"
+    else if isList args.phases then
+      args.phases
+    else
+      let
+        e = args.phases;
+        known = buildSystems.${head uses}.phases;
+        named =
+          attrNames (e.before or { })
+          ++ attrNames (e.after or { })
+          ++ attrNames (e.replace or { })
+          ++ (e.remove or [ ]);
+        unknown = filter (n: !elem n known) named;
+        bad = filter (
+          n:
+          !elem n [
+            "before"
+            "after"
+            "replace"
+            "remove"
+          ]
+        ) (attrNames e);
+        asList = x: if isList x then x else [ x ];
+      in
+      if bad != [ ] then
+        fail "phases: unknown edit ${head bad} (before, after, replace, remove)"
+      else if unknown != [ ] then
+        fail "phases: ${head unknown} is not a phase of ${head uses} (${concatStringsSep " " known})"
+      else
+        concatMap (
+          p:
+          if elem p (e.remove or [ ]) then
+            [ ]
+          else
+            (e.before.${p} or [ ]) ++ asList (e.replace.${p} or p) ++ (e.after.${p} or [ ])
+        ) known;
   testsRun = args.tests.run or true;
   # a build system's `stack` (tools that are themselves built with it): a member sees only the
   # members before it, everyone else sees all of it

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -78,26 +78,42 @@ let
       pinned = if pin == { } then t.pin or { } else (t.pin or { }) // pin;
       version = pinned.version or "";
       tag = pinned.tag or version;
-      mm = builtins.match "([^.]*)\\.?([^.]*).*" version;
-      # every [pin] key is a {key} placeholder, plus three spellings derived from the version
-      vars = {
-        tag = version;
-        version_ = builtins.replaceStrings [ "." ] [ "_" ] version;
-        major = builtins.elemAt mm 0;
-        minor = builtins.elemAt mm 1;
-      }
-      // pinned;
-      expand = builtins.replaceStrings (map (k: "{${k}}") (builtins.attrNames vars)) (
-        map toString (builtins.attrValues vars)
-      );
+      # every [pin] key is a {key} placeholder, plus three spellings derived from the version.
+      # Nearly every url uses {version} and {tag} only: the full table is built for the rest
+      expandAll =
+        let
+          mm = builtins.match "([^.]*)\\.?([^.]*).*" version;
+          vars = {
+            tag = version;
+            version_ = builtins.replaceStrings [ "." ] [ "_" ] version;
+            major = builtins.elemAt mm 0;
+            minor = builtins.elemAt mm 1;
+          }
+          // pinned;
+        in
+        builtins.replaceStrings (map (k: "{${k}}") (builtins.attrNames vars)) (
+          map toString (builtins.attrValues vars)
+        );
+      expand =
+        u:
+        let
+          quick = builtins.replaceStrings [ "{version}" "{tag}" ] [ version tag ] u;
+        in
+        if builtins.match ".*[{].*" quick == null then quick else expandAll quick;
+      sources = t.source or [ ];
+      # one `default` source is the common case: no table
       byKey =
         let
-          plain = builtins.listToAttrs (
-            map (s: {
-              name = s.key;
-              value = s;
-            }) (t.source or [ ])
-          );
+          plain =
+            if builtins.length sources == 1 && (builtins.head sources).key == "default" then
+              { default = builtins.head sources; }
+            else
+              builtins.listToAttrs (
+                map (s: {
+                  name = s.key;
+                  value = s;
+                }) sources
+              );
         in
         if hashes == { } then
           plain

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -16,13 +16,40 @@ let
     stringLength
     ;
   hasPrefix = p: s: substring 0 (stringLength p) s == p;
-  # the url itself, then the same path on every mirror of its prefix (nix/mirrors.nix)
+  # the url itself, then the same path on every mirror of its prefix (nix/mirrors.nix). Mirrors
+  # are indexed by host so most urls cost one lookup, not a scan
+  byHost = builtins.groupBy (p: builtins.elemAt (builtins.match "https://([^/]*)/.*" p) 0) (
+    attrNames mirrors
+  );
   withMirrors =
     url:
+    let
+      host = builtins.match "https://([^/]*)/.*" url;
+      prefixes = if host == null then [ ] else byHost.${builtins.elemAt host 0} or [ ];
+    in
     [ url ]
     ++ concatMap (p: map (m: m + substring (stringLength p) (-1) url) mirrors.${p}) (
-      filter (p: hasPrefix p url) (attrNames mirrors)
+      filter (p: hasPrefix p url) prefixes
     );
+  # what every fetch-and-unpack derivation shares
+  fetchCommon = {
+    inherit system unpacker;
+    builder = "${unpacker}/bin/nu";
+    args = [
+      "--no-config-file"
+      ../pkgs/up/uptrack/src/unpack.nu
+      "--fetch"
+    ];
+    outputHashMode = "recursive";
+    preferLocalBuild = true;
+    impureEnvVars = [
+      "http_proxy"
+      "https_proxy"
+      "ftp_proxy"
+      "all_proxy"
+      "no_proxy"
+    ];
+  };
   # "llvm-project-21.1.8.src" from …/llvm-project-21.1.8.src.tar.xz, "fd-v10.5.0" for github tag archives
   # strip one extension, and a ".tar" before it
   stripExt =
@@ -63,12 +90,19 @@ let
       expand = builtins.replaceStrings (map (k: "{${k}}") (builtins.attrNames vars)) (
         map toString (builtins.attrValues vars)
       );
-      byKey = builtins.listToAttrs (
-        map (s: {
-          name = s.key;
-          value = if hashes ? ${s.key} then s // { hash = hashes.${s.key}; } else s;
-        }) (t.source or [ ])
-      );
+      byKey =
+        let
+          plain = builtins.listToAttrs (
+            map (s: {
+              name = s.key;
+              value = s;
+            }) (t.source or [ ])
+          );
+        in
+        if hashes == { } then
+          plain
+        else
+          builtins.mapAttrs (k: s: if hashes ? ${k} then s // { hash = hashes.${k}; } else s) plain;
       fetch =
         key:
         let
@@ -92,27 +126,14 @@ let
             unpack = isNar;
           }
         else
-          derivation {
-            inherit name system;
-            urls = withMirrors url;
-            builder = "${unpacker}/bin/nu";
-            args = [
-              "--no-config-file"
-              ../pkgs/up/uptrack/src/unpack.nu
-              "--fetch"
-            ];
-            inherit unpacker;
-            outputHashMode = "recursive";
-            outputHash = s.hash;
-            preferLocalBuild = true;
-            impureEnvVars = [
-              "http_proxy"
-              "https_proxy"
-              "ftp_proxy"
-              "all_proxy"
-              "no_proxy"
-            ];
-          };
+          derivation (
+            fetchCommon
+            // {
+              inherit name;
+              urls = withMirrors url;
+              outputHash = s.hash;
+            }
+          );
     in
     {
       inherit version tag fetch;

--- a/pkgs/au/autoconf/package.nix
+++ b/pkgs/au/autoconf/package.nix
@@ -17,10 +17,7 @@ package {
     pkgs.perl
     pkgs.bash
   ];
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.install"
+  phases.after."autotools.install" = [
     {
       name = "retarget";
       run = ''

--- a/pkgs/gi/git/package.nix
+++ b/pkgs/gi/git/package.nix
@@ -16,12 +16,7 @@ package {
   ];
   cargo.tool = buildPkgs.rust-bootstrap;
   cargo.deps = null;
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.test"
-    "autotools.install"
-  ];
+  phases = { }; # autotools', cargo only sets up
   autotools.outOfTree = false;
   autotools.flags = [
     "--with-curl"


### PR DESCRIPTION
`phases` can now edit the build system's list instead of restating it:

```nix
phases.after."autotools.install" = [ { name = "retarget"; run = ''…''; } ];
phases.replace."cmake.configure" = { name = "configure"; run = ''…''; };
phases.remove = [ "cmake.test" ];
```

`before`, `after` and `replace` take a phase or a list of phases. `remove` takes a list. A phase name the build system does not have is an error at evaluation time. `phases = [ … ]` still writes out the whole order when that is clearer. 18 packages that restated the default list to add or drop a step now use the edits.

This costs less than one thunk per package when unused. A systemd-style unit graph was measured too and allocates six times as much.

The remaining commits are eval savings found while measuring: 31 632 → 26 827 thunks and 2.86 → 2.21 MB over the native set, with identical derivations.

Closes #5