### PR TITLE
use phase edits where a package restated the default list

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ list. A phase is one of a build system's or a piece of nu with a name. Inside th
 the paths and facts of the build (`$c.out`, `$c.src`, `$c.build`, `$c.njobs`, `$c.platform`):
 
 ```nix
-phases.before."autotools.install" = [
-  { name = "trim"; run = ''rm $"($c.build)/unwanted"''; }
-];
-phases.remove = [ "autotools.test" ];
+phases.after."autotools.install" = { name = "sh-alias"; run = ''^ln -s bash $"($c.out)/bin/sh"''; };
+phases.replace."autotools.configure" = "perl.configure";
+phases.remove = [ "cargo.test" ];
 ```
 
-`phases = [ … ]` spells the whole list out instead, needed with more than one build system.
+`phases = [ … ]` spells the whole list out instead. With several build systems the edits apply
+to the first one's list.
 
 Phases too long to keep inline can live in their own file: `modules.rust = ./build.nu;` makes it
 a module, and `phases` refers to them as `"rust.configure"`. pkgs/ru/rust does this.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -297,7 +297,7 @@ let
           if elem p (e.remove or [ ]) then
             [ ]
           else
-            (e.before.${p} or [ ]) ++ asList (e.replace.${p} or p) ++ (e.after.${p} or [ ])
+            asList (e.before.${p} or [ ]) ++ asList (e.replace.${p} or p) ++ asList (e.after.${p} or [ ])
         ) known;
   testsRun = args.tests.run or true;
   # a build system's `stack` (tools that are themselves built with it): a member sees only the

--- a/pkgs/ba/bash/package.nix
+++ b/pkgs/ba/bash/package.nix
@@ -13,10 +13,7 @@ package {
   ];
   tests.relocated = true;
   tests.run = false; # interactive/tty
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.install"
+  phases.after."autotools.install" = [
     {
       name = "sh-alias";
       run = "^ln -s bash $\"($c.out)/bin/sh\"";

--- a/pkgs/co/corrosion/package.nix
+++ b/pkgs/co/corrosion/package.nix
@@ -4,11 +4,7 @@ package {
   uses = [ "cmake" ];
   # configure checks that cargo and rustc exist
   buildDependencies = [ buildPkgs.rust ];
-  phases = [
-    "cmake.configure"
-    "cmake.build"
-    "cmake.install"
-  ]; # its tests build dozens of crates from the network
+  phases.remove = [ "cmake.test" ]; # its tests build dozens of crates from the network
   cmake.defs = {
     CORROSION_BUILD_TESTS = false;
   };

--- a/pkgs/cu/curl/package.nix
+++ b/pkgs/cu/curl/package.nix
@@ -19,10 +19,7 @@ package {
     CURL_CA_SEARCH_SAFE = true;
   };
   tests.run = false; # needs perl + python impacket + minutes
-  phases = [
-    "cmake.configure"
-    "cmake.build"
-    "cmake.install"
+  phases.after."cmake.install" = [
     {
       # `curl-config --cc` would echo the build compiler's store path
       name = "curl-config";

--- a/pkgs/el/elixir/package.nix
+++ b/pkgs/el/elixir/package.nix
@@ -10,11 +10,7 @@ package {
   uses = [ "autotools" ];
   autotools.outOfTree = false;
   autotools.testTarget = [ "test_stdlib" ]; # test_mix wants git and network
-  phases = [
-    "autotools.build"
-    "autotools.test"
-    "autotools.install"
-  ];
+  phases.remove = [ "autotools.configure" ];
   buildDependencies = [ buildPkgs.erlang ];
   dependencies = [
     pkgs.erlang

--- a/pkgs/fo/formatelf/package.nix
+++ b/pkgs/fo/formatelf/package.nix
@@ -9,10 +9,7 @@ package {
   uses = [ "cargo" ];
   # tree infrastructure (finish.nu implants prebuilt ELFs with it): must not wait for llvm + rust
   cargo.tool = buildPkgs.rust-bootstrap;
-  phases = [
-    "cargo.build"
-    "cargo.test"
-    "cargo.install"
+  phases.after."cargo.install" = [
     {
       name = "personalities";
       run = "for n in [auto-formatelf patchelf] { ^ln -s formatelf $\"($c.out)/bin/($n)\" }";

--- a/pkgs/gr/grep/package.nix
+++ b/pkgs/gr/grep/package.nix
@@ -6,10 +6,7 @@ package {
   autotools.flags = [ "--disable-perl-regexp" ];
   tests.relocated = true;
   tests.run = false; # perl
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.install"
+  phases.after."autotools.install" = [
     {
       # deprecated sh wrappers whose #! would be the build shell
       name = "drop-egrep";

--- a/pkgs/ji/jigd/package.nix
+++ b/pkgs/ji/jigd/package.nix
@@ -7,8 +7,5 @@ package {
   uses = [ "go" ];
   go.cgo = false;
   tests.version = false; # a daemon, no --version
-  phases = [
-    "go.build"
-    "go.install"
-  ];
+  phases.remove = [ "go.test" ];
 }

--- a/pkgs/lu/lua/package.nix
+++ b/pkgs/lu/lua/package.nix
@@ -6,15 +6,13 @@ package {
   name = "lua";
   uses = [ "autotools" ];
   autotools.outOfTree = false;
-  phases = [
+  phases.before."autotools.build" = [
     {
       name = "lua-root";
       run = "cd $c.src; open --raw src/luaconf.h | str replace /usr/local/ $'($c.out)/' | save -f src/luaconf.h";
     }
-    "autotools.build"
-    "autotools.test"
-    "autotools.install"
   ];
+  phases.remove = [ "autotools.configure" ];
   autotools.buildTarget = [
     {
       linux = "linux";

--- a/pkgs/lu/luarocks/package.nix
+++ b/pkgs/lu/luarocks/package.nix
@@ -15,18 +15,17 @@ package {
     pkgs.unzip
   ];
   buildDependencies = [ buildPkgs.unzip ];
-  phases = [
-    {
-      name = "configure";
-      run = "cd $c.src; x ./configure $\"--prefix=($c.out)\" $\"--with-lua=(dep-root lua 'luarocks runs on it')\"";
-    }
-    "autotools.build"
-    "autotools.install"
+  phases.replace."autotools.configure" = {
+    name = "configure";
+    run = "cd $c.src; x ./configure $\"--prefix=($c.out)\" $\"--with-lua=(dep-root lua 'luarocks runs on it')\"";
+  };
+  phases.after."autotools.install" = [
     {
       name = "cc";
       run = "for f in (glob $\"($c.out)/etc/luarocks/config-*.lua\") { \"\\nvariables.CC = \\\"cc\\\"\\nvariables.LD = \\\"cc\\\"\\n\" | save -a $f }";
     }
   ];
+  phases.remove = [ "autotools.test" ];
   bin = [
     "luarocks"
     "luarocks-admin"

--- a/pkgs/ma/maturin/package.nix
+++ b/pkgs/ma/maturin/package.nix
@@ -6,8 +6,5 @@ package {
   name = "maturin";
   uses = [ "cargo" ];
   cargo.noDefaultFeatures = true;
-  phases = [
-    "cargo.build"
-    "cargo.install"
-  ];
+  phases.remove = [ "cargo.test" ];
 }

--- a/pkgs/nc/ncurses/package.nix
+++ b/pkgs/nc/ncurses/package.nix
@@ -31,18 +31,16 @@ package {
     else
       [ ]
   );
-  phases = [
-    {
-      name = "configure";
-      run = ''
-        # configure derives the .pc dir from pkg-config's search path otherwise
-        $env.PKG_CONFIG_LIBDIR = $"($c.out)/lib/pkgconfig"
-        $env.BUILD_CC = $env.CC_FOR_BUILD # cross: it guesses gcc
-        autotools configure
-      '';
-    }
-    "autotools.build"
-    "autotools.install"
+  phases.replace."autotools.configure" = {
+    name = "configure";
+    run = ''
+      # configure derives the .pc dir from pkg-config's search path otherwise
+      $env.PKG_CONFIG_LIBDIR = $"($c.out)/lib/pkgconfig"
+      $env.BUILD_CC = $env.CC_FOR_BUILD # cross: it guesses gcc
+      autotools configure
+    '';
+  };
+  phases.after."autotools.install" = [
     {
       name = "compat-links";
       run = ''

--- a/pkgs/op/openssl/package.nix
+++ b/pkgs/op/openssl/package.nix
@@ -8,22 +8,19 @@ package {
   cc.cflags = [ "-DOSSL_RELOCATABLE" ];
   uses = [ "autotools" ];
   # own perl Configure. --openssldir is the §3 ambient path, not a store path
-  phases = [
-    {
-      name = "configure";
-      run = ''
-        cd $c.build
-        let target = ({x86_64: "linux-x86_64", aarch64: "linux-aarch64", riscv64: "linux64-riscv64"} | get ($c.platform.triple | split row '-' | first))
-        x perl $"($c.src)/Configure" $target $"--prefix=($c.out)" "--libdir=lib" "--openssldir=/etc/ssl" shared no-docs no-tests enable-ktls
-      '';
-    }
-    "autotools.build"
-    {
-      name = "install";
-      run = "cd $c.build; x make install_sw install_ssldirs $\"OPENSSLDIR=($c.out)/etc/ssl\"; rm $\"($c.out)/bin/c_rehash\"";
-    } # perl script; would make perl a runtime dependency
-
-  ];
+  phases.replace."autotools.configure" = {
+    name = "configure";
+    run = ''
+      cd $c.build
+      let target = ({x86_64: "linux-x86_64", aarch64: "linux-aarch64", riscv64: "linux64-riscv64"} | get ($c.platform.triple | split row '-' | first))
+      x perl $"($c.src)/Configure" $target $"--prefix=($c.out)" "--libdir=lib" "--openssldir=/etc/ssl" shared no-docs no-tests enable-ktls
+    '';
+  };
+  phases.replace."autotools.install" = {
+    name = "install";
+    run = "cd $c.build; x make install_sw install_ssldirs $\"OPENSSLDIR=($c.out)/etc/ssl\"; rm $\"($c.out)/bin/c_rehash\""; # perl script; would make perl a runtime dependency
+  };
+  phases.remove = [ "autotools.test" ];
   buildDependencies = [ buildPkgs.perl ];
   tests.version = "version";
 }

--- a/pkgs/pe/perl/package.nix
+++ b/pkgs/pe/perl/package.nix
@@ -11,13 +11,8 @@ package {
   uses = [ "autotools" ];
   bootstrapTools = true;
   autotools.outOfTree = false;
-  phases = [
-    "perl.configure"
-    "autotools.build"
-    "autotools.test"
-    "autotools.install"
-    "perl.scrub"
-  ];
+  phases.replace."autotools.configure" = "perl.configure";
+  phases.after."autotools.install" = "perl.scrub";
   env =
     if platform.cross then
       {

--- a/pkgs/pk/pkgconf/package.nix
+++ b/pkgs/pk/pkgconf/package.nix
@@ -11,10 +11,7 @@ package {
     "--with-system-includedir=/nonexistent"
   ];
   tests.run = false; # kyua
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.install"
+  phases.after."autotools.install" = [
     {
       name = "pkg-config-alias";
       run = "^ln -s pkgconf $\"($c.out)/bin/pkg-config\"";

--- a/pkgs/ru/ruby/package.nix
+++ b/pkgs/ru/ruby/package.nix
@@ -26,10 +26,7 @@ package {
     pkgs.libyaml
     pkgs.libffi
   ];
-  phases = [
-    "autotools.configure"
-    "autotools.build"
-    "autotools.install"
+  phases.after."autotools.install" = [
     {
       # rbconfig.rb describes the build machine: configure's bash and clang's InstalledDir line
       name = "rbconfig";

--- a/pkgs/sv/svgo/package.nix
+++ b/pkgs/sv/svgo/package.nix
@@ -4,13 +4,9 @@
 package {
   name = "svgo";
   uses = [ "pnpm" ];
-  phases = [
-    "pnpm.build"
-    {
-      # test/regression diffs against a `git rev-parse HEAD` baseline, no repo in a tarball
-      name = "test";
-      run = "x pnpm exec vitest run --exclude test/regression";
-    }
-    "pnpm.install"
-  ];
+  phases.replace."pnpm.test" = {
+    # test/regression diffs against a `git rev-parse HEAD` baseline, no repo in a tarball
+    name = "test";
+    run = "x pnpm exec vitest run --exclude test/regression";
+  };
 }

--- a/pkgs/ut/utf8cpp/package.nix
+++ b/pkgs/ut/utf8cpp/package.nix
@@ -2,8 +2,9 @@
 package {
   name = "utf8cpp";
   uses = [ "cmake" ];
-  phases = [
-    "cmake.configure"
-    "cmake.install"
-  ]; # header-only
+  # header-only
+  phases.remove = [
+    "cmake.build"
+    "cmake.test"
+  ];
 }

--- a/pkgs/zi/zig/package.nix
+++ b/pkgs/zi/zig/package.nix
@@ -27,13 +27,8 @@ package {
   prebuilt = true;
   # zig's own cache (default $HOME/.cache). zig.nu saves and restores it through jigd
   env.ZIG_GLOBAL_CACHE_DIR = "/build/zig-cache";
-  phases = [
-    "cmake.configure"
-    "zig.restore"
-    "cmake.build"
-    "zig.store"
-    "cmake.install"
-  ];
+  phases.after."cmake.configure" = "zig.restore";
+  phases.after."cmake.build" = "zig.store";
   tests.run = false; # `zig build test` is the multi-hour compiler suite
   tests.version = "version";
 }


### PR DESCRIPTION
The last commit of #6, which was merged before it landed: 18 packages switch from a full `phases` list to `before`/`after`/`replace`/`remove`, and `before`/`after` accept a single phase.